### PR TITLE
Support for stor.open on DNAnexus paths

### DIFF
--- a/docs/dx.rst
+++ b/docs/dx.rst
@@ -1,0 +1,160 @@
+.. _dx:
+
+DNAnexus
+========
+
+Canonical Paths on DNAnexus
+---------------------------
+Every file resource on DNAnexus is given a canonical ID to refer it by. This is
+internally given by the platform and is not determined by stor. However, stor
+does provide the option of referring to the resource through their canonical IDs.
+Each individual project and file has a canonical ID associated with it. This
+ID consists of 24 case-sensitive characters from ``0123456789BFGJKPQVXYZbfgjkpqvxyz``
+prepended with 'project-' or 'file-' respectively. Example canonical IDs are
+``project-j47b1k3z8Jqqv001213v312j1``, and ``file-47jK67093475061g3v95369p``.
+
+Each individual file with its unique ID, can manifest in only one project on
+DNAnexus. This is because the metadata associated with the file in that project
+can only have one path to the file. Also, since the canonicalized path to the
+file on DNAnexus is represented by::
+
+    'project-j47b1k3z8Jqqv001213v312j1:file-47jK67093475061g3v95369p'
+
+each project can only have each canonical file at one location within the project.
+However, one canonical file can be present in multiple projects at different paths.
+
+Thus, stor has two subclass implementations of `DXPath`: `DXCanonicalPath` and
+`DXVirtualPath`. As the name suggests, `DXCanonicalPath` deals with paths like::
+
+    Path('dx://project-j47b1k3z8Jqqv001213v312j1:file-47jK67093475061g3v95369p')
+    OR
+    Path('dx://project-j47b1k3z8Jqqv001213v312j1')
+
+`DXVirtualPath` handles paths that have any human readable element in them::
+
+    Path('dx://project-j47b1k3z8Jqqv001213v312j1:/path/to/file.txt')
+    OR
+    Path('dx://myproject:/path/to/file.txt')
+
+You can obtain the `DXCanonicalPath` for a resource from a `DXVirtualPath`
+and vice versa.
+
+Projects on DNAnexus
+--------------------
+All resources on the DX platform are organized into projects, which is the main
+container of the resource. The access and billing etc permissions to the resource
+are determined by (and the same as) the user's permission to the project.
+
+On stor, the project is the first part of any `DXPath` and is unique because
+it must end in a trailing ':'. Every `DXPath` must have a project associated.
+More on this later.
+
+Directories on DNAnexus
+-----------------------
+DNAnexus has the concept of directories on the platform like posix (unlike
+Swift/S3). These directories can be empty, and also have names with extensions.
+Two folders with the same parent path cannot have the same name, i.e., no
+duplicate folders are allowed (like posix).
+
+Note here that folders are not actual resources on the DNAnexus platform.
+They are only handled through metadata on the server and as a result, do not
+have a canonical ID of their own. As a result, paths to folders can only be
+`DXVirtualPath`. Accessing the `DXVirtualPath.canonical_path` property for folders
+would raise an error.
+
+Files on DNAnexus
+-----------------
+Files stored on the DX platform are immutable. This is because the files are
+internally stored in AWS while the metadata handling is taken care of by the
+platform. Hence, once a file is uploaded, it cannot be modified.
+
+When one file is copied to another project, only additional metadata is produced,
+while the underlying file on AWS remains the same. This is essential. The same
+file with the same canonical ID will appear in both projects, and can have
+different folder paths. Deleting a file from one project is possible, which
+deletes the metadata and leaves the file untouched in other projects.
+
+DXPath on stor
+--------------
+All `DXPath` instances on stor must have a project. The project is the first part
+of the path and is determined by a trailing ``:``. Thus, paths without a project
+like::
+
+    Path('dx://')
+    OR
+    Path('dx://path/to/file')
+
+can never be initialized on stor. Trying so will result in an error. The one and
+only exception to this scenario is when only a project is mentioned. Thus,::
+
+    Path('dx://myproject:')
+    OR
+    Path('dx://myproject')
+
+both are valid, and essentially refer to the same proejct path.
+
+Files and directories can have the same name on the DX platform. This is because
+files without extentions and/or directories with extensions are allowed. A
+`DXPath` instance on stor can be ambiguous as a result. For example, the path::
+
+    Path('dx://myproject:/path/to/folder_file')
+
+can refer to a file and/or a folder, since ``folder_file`` can be a folder and/or
+a file. Hence different operations may refer to the different underlying object.
+As an example, `DXPath.listdir` would treat the above path as a folder, while
+`DXPath.stat` would treat the same path as a file.
+
+DXPath
+-------
+
+.. automodule:: stor.dx
+    :members:
+
+Behavior of copy and copytree
+-----------------------------
+Since there are directories on DNAnexus, and  a file and a folder with the
+same path can also have duplicate names, copy and copytree work differently
+on the platform compared to other OBS services (Swift/S3).
+
+Suppose we are trying to copy a file to a destination path::
+
+    stor.copy('dx://project1:/folder/file.txt', 'dx://project2:/new_folder')
+    OR
+    Path('dx://project1:/folder/file.txt').copy('dx://project2:/new_folder')
+
+The outcome of the above commands is determined by the file/folder structure
+already present at the destination. If ``project2:/new_folder`` is an already
+existing directory, stor will attempt to copy the file under that folder (i.e.
+as ``dx://project2:/new_folder/file.txt``. However, if this final destination
+path also exists, it raises a `TargetExistsError`.
+Conversely, if ``project2:/new_folder`` is not an existing directory, stor
+attempts to copy ``file.txt`` to ``project2:/new_folder`` as a file (remember:
+files without extensions are allowed, hence stor has no reason to believe
+``new_folder`` is not a filename we're trying to copy to). Thus, stor will
+copy that file to the *file* ``project2:/new_folder``. The caveat here again
+is that if ``project2:/new_folder`` already existed as a file, a
+`TargetExistsError` is thrown.
+
+Copytree also works in a similar fashion, wherein directory names are compared,
+instead of filenames. Suppose we are trying to copytree a directory::
+
+    stor.copytree('dx://project1:/folder', 'dx://project2:/new_folder')
+    OR
+    Path('dx://project1:/folder').copytree('dx://project2:/new_folder')
+
+Again, if the ``project2:/new_folder`` is an already existing directory,stor
+will attempt to copy the folder as a subfolder to that directory (i.e. as
+``dx://project2:/new_folder/folder``. If this new destination is also already
+present, a `TargetExistsError` is raised. If ``project2:/new_folder`` is not
+originally present, then the folder is copied to this path.
+
+The above discussion was for DNAnexus to DNAnexus paths. The scenario shifts
+for posix to DX or DX to posix paths. For posix to DX paths, the destination
+mentioned in the copy/copytree command is never altered based on the dest
+filesystem. The original destination mentioned in the command is taken to be
+the only intended endpoint. Thus, in our scenario above, if ``project2:/new_folder``
+does not exist as a file, the copy is done to that file, else a `TargetExistsError`
+is raised. Similarly for copytree on a directory. This behavior is the same
+as other OBS services (SwiFT/S3) that has been traditionally applied.
+For DX to posix paths also, the traditional behavior has been followed,
+to maintain consistency on posix systems.

--- a/docs/dx.rst
+++ b/docs/dx.rst
@@ -146,7 +146,7 @@ Again, if the ``project2:/new_folder`` is an already existing directory, stor
 will set the new destination for the folder as a subfolder to that directory
 (i.e. as ``dx://project2:/new_folder/folder``. However, if this new destination is
 already present, a `TargetExistsError` is raised, instead of deleting it like in
-`copy`, because we don't wish to delete full directories through copytree
+`DXPath.copy`, because we don't wish to delete full directories through copytree
 (use `DXPath.rmtree` for that) or merge two directories. If ``project2:/new_folder``
 is not originally present, then the folder is copied to this path.
 
@@ -163,7 +163,7 @@ to maintain consistency on posix systems.
 
 Open on stor
 ------------
-The `DXPath.open` functionality in stor works by returning an instance of
+The ``open`` functionality in stor works by returning an instance of
 ``stor.obs.OBSFile`` like with other OBS paths(Swift/S3). Although the python
 package of DNAnexus ``dxpy`` also has an open functionality on their DXFile,
 this is not carried over to stor. One of the main reasons to do this is to wrap
@@ -174,5 +174,5 @@ to their ``DXFile.open`` which can be confusing to a stor user, because there
 are very restricted scenarios this can be used in, and the user would have to
 know the different internal states of a file on the DNAnexus platform,
 what they mean, when they happen, what operations are allowed on them, etc.
-By instantiating ``stor.obs.OBSFile`` for `DXPath.open`, we maintain the
+By instantiating ``stor.obs.OBSFile`` for ``open``, we maintain the
 support that is standard by stor, without any real decrease in functionality.

--- a/docs/swift.rst
+++ b/docs/swift.rst
@@ -77,13 +77,6 @@ Note that if you want to combine multiple conditions, you can do this easily as:
   condition = lambda results: all(f(results) for f in my_list_of_conditions)
 
 
-SwiftFile
----------
-
-.. autoclass:: SwiftFile
-  :members:
-
-
 SwiftUploadObject
 -----------------
 

--- a/docs/toc.rst
+++ b/docs/toc.rst
@@ -10,6 +10,7 @@ Table of Contents
    main_interface
    swift
    s3
+   dx
    posix
    windows
    exceptions

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ testfixtures==4.7.0
 coverage==4.4.1
 pytest==3.2.3
 pytest-cov==2.5.1
-vcrpy-unittest
+vcrpy

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -142,12 +142,35 @@ class OBSPath(Path):
         """
         raise NotImplementedError
 
-    def open(self, mode='r', encoding=None):
+    def open(self, mode='r', encoding=None, **kwargs):
         """
         Opens a OBSFile that can be read or written to and is uploaded to
         the remote service.
+
+        For examples of reading and writing opened objects, view
+        OBSFile.
+
+        Args:
+            mode (str): The mode of object IO. Currently supports reading
+                ("r" or "rb") and writing ("w", "wb")
+            encoding (str): text encoding to use. Defaults to
+                ``locale.getpreferredencoding(False)`` (Python 3 only)
+            kwargs (dict): DEPRECATED FOR SWIFT (use `stor.settings.use()`
+                instead). A dictionary of arguments that will be
+                passed as keyword args to `SwiftPath.upload` or `DXPath.upload`
+                if any writes occur on the opened resource.
+
+        Returns:
+            OBSFile: The file object for Swift/S3/DX.
+
+        Raises:
+            SwiftError: A swift client error occurred.
+            DNAnexusError: A dxpy client error occured.
+            RemoteError: A s3 client error occurred.
         """
-        raise NotImplementedError
+        swift_upload_options = kwargs.pop('swift_upload_options', {})
+        kwargs.update(**swift_upload_options)
+        return OBSFile(self, mode=mode, encoding=encoding, **kwargs)
 
     def list(self):
         """List contents using the resource of the path as a prefix."""

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -20,7 +20,6 @@ from stor import exceptions
 from stor import settings
 from stor import utils
 from stor.base import Path
-from stor.obs import OBSFile
 from stor.obs import OBSPath
 from stor.obs import OBSUploadObject
 
@@ -29,8 +28,6 @@ _thread_local = threading.local()
 
 logger = logging.getLogger(__name__)
 progress_logger = logging.getLogger('%s.progress' % __name__)
-
-S3File = OBSFile
 
 
 def _parse_s3_error(exc, **kwargs):
@@ -227,27 +224,6 @@ class S3Path(OBSPath):
             six.raise_from(exceptions.FailedUploadError(str(e), e), e)
         except boto3_exceptions.RetriesExceededError as e:
             six.raise_from(exceptions.FailedDownloadError(str(e), e), e)
-
-    def open(self, mode='r', encoding=None):
-        """
-        Opens a S3File that can be read or written to.
-
-        For examples of reading and writing opened objects, view
-        S3File.
-
-        Args:
-            mode (str): The mode of object IO. Currently supports reading
-                ("r" or "rb") and writing ("w", "wb")
-            encoding (str): text encoding to use. Defaults to
-                ``locale.getpreferredencoding(False)`` (Python 3 only).
-
-        Returns:
-            S3File: The s3 object.
-
-        Raises:
-            RemoteError: A s3 client error occurred.
-        """
-        return S3File(self, mode=mode, encoding=encoding)
 
     def list(self,
              starts_with=None,

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -54,7 +54,6 @@ from stor import is_swift_path
 from stor import settings
 from stor import utils
 from stor.base import Path
-from stor.obs import OBSFile
 from stor.obs import OBSPath
 from stor.obs import OBSUploadObject
 from stor.posix import PosixPath
@@ -102,7 +101,6 @@ ConditionNotMetError = stor_exceptions.ConditionNotMetError
 ConflictError = stor_exceptions.ConflictError
 UnavailableError = stor_exceptions.UnavailableError
 UnauthorizedError = stor_exceptions.UnauthorizedError
-SwiftFile = OBSFile
 SwiftUploadObject = OBSUploadObject
 
 
@@ -671,31 +669,6 @@ class SwiftPath(OBSPath):
             fp.flush()
             suo = OBSUploadObject(fp.name, object_name=self.resource)
             return self.upload([suo], **swift_upload_args)
-
-    def open(self, mode='r', encoding=None, swift_upload_options=None):
-        """Opens a `SwiftFile` that can be read or written to.
-
-        For examples of reading and writing opened objects, view
-        `SwiftFile`.
-
-        Args:
-            mode (str): The mode of object IO. Currently supports reading
-                ("r" or "rb") and writing ("w", "wb")
-            encoding (str): text encoding to use. Defaults to
-                ``locale.getpreferredencoding(False)`` (Python 3 only)
-            swift_upload_options (dict): DEPRECATED (use `stor.settings.use()`
-                instead). A dictionary of arguments that will be
-                passed as keyword args to `SwiftPath.upload` if any writes
-                occur on the opened resource.
-
-        Returns:
-            SwiftFile: The swift object.
-
-        Raises:
-            SwiftError: A swift client error occurred.
-        """
-        swift_upload_options = swift_upload_options or {}
-        return SwiftFile(self, mode=mode, encoding=encoding, **swift_upload_options)
 
     @_swift_retry(exceptions=(ConditionNotMetError, UnavailableError))
     def list(self,


### PR DESCRIPTION
# Motivation
As part of DNAnexus support on stor

# Implementation
- Implemented read and write on stor paths.
- Although DNAnexus file natively support 'append' mode, this is not supported here to avoid confusion.
- Added test cases for the same.