### PR TITLE
Fix splitdrive for OBSPath

### DIFF
--- a/stor/obs.py
+++ b/stor/obs.py
@@ -123,6 +123,10 @@ class OBSPath(Path):
 
         return self.parts_class(joined_resource) if joined_resource else None
 
+    def splitdrive(self):
+        """Split drive for obs paths from the rest"""
+        return self.path_class(self.drive), self[len(self.drive):]
+
     def normpath(self):
         """Normalize path following linux conventions (keeps drive prefix)"""
         normed = posixpath.normpath('/' + str(self)[len(self.drive):])[1:]

--- a/stor/tests/test_dx_path_compat.py
+++ b/stor/tests/test_dx_path_compat.py
@@ -223,3 +223,9 @@ class TestBasics(unittest.TestCase):
         assert f.splitpath() == (DXCanonicalPath("dx://project-123456789012345678901234:"), '')
         f = DXPath('dx://project-123456789012345678901234')
         assert f.splitpath() == (DXCanonicalPath("dx://project-123456789012345678901234:"), '')
+
+    def test_splitdrive(self):
+        f = DXPath('dx://')
+        assert f.splitdrive() == (DXPath('dx://'), '')
+        f = DXPath('dx://project:prefix/dir/file')
+        assert f.splitdrive() == (DXPath('dx://'), 'project:prefix/dir/file')

--- a/stor/tests/test_s3_path_compat.py
+++ b/stor/tests/test_s3_path_compat.py
@@ -54,3 +54,9 @@ class TestBasics(unittest.TestCase):
         # .ext
         self.assertEqual(f.ext, '.csv')
         self.assertEqual(f.parent.ext, '')
+
+    def test_splitdrive(self):
+        f = S3Path('s3://')
+        assert f.splitdrive() == (S3Path('s3://'), '')
+        f = S3Path('s3://bucket/prefix/whatever.csv')
+        assert f.splitdrive() == (S3Path('s3://'), 'bucket/prefix/whatever.csv')

--- a/stor/tests/test_swift_path_compat.py
+++ b/stor/tests/test_swift_path_compat.py
@@ -54,3 +54,9 @@ class TestBasics(unittest.TestCase):
         # .ext
         self.assertEqual(f.ext, '.csv')
         self.assertEqual(f.parent.ext, '')
+
+    def test_splitdrive(self):
+        f = SwiftPath("swift://")
+        assert f.splitdrive() == (SwiftPath('swift://'), '')
+        f = SwiftPath("swift://foo")
+        assert f.splitdrive() == (SwiftPath('swift://'), 'foo')


### PR DESCRIPTION
@jtratner CC @pkaleta 

This PR fixes the splitdrive function for all obs paths. Earlier it defaulted to posix's behavior, which led to errors.

The base of this PR needs to be changed to Counsyl's after it's approved and after [this PR](https://github.com/counsyl/stor/pull/113) has been merged, before merging this.